### PR TITLE
Added new data type for accelerometer of oral-B 9000 brushes

### DIFF
--- a/datakitapi/src/main/java/org/md2k/datakitapi/source/datasource/DataSourceType.java
+++ b/datakitapi/src/main/java/org/md2k/datakitapi/source/datasource/DataSourceType.java
@@ -120,7 +120,8 @@ public class DataSourceType {
     public static final String ORALB_SECTOR="ORALB_SECTOR";
     public static final String ORALB_BRUSHING_MODE="ORALB_BRUSHING_MODE";
     public static final String ORALB_BRUSHING_STATE="ORALB_BRUSHING_STATE";
-    public static final String ORALB_BUSHING_TIME="ORALB_BUSHING_TIME";
+    public static final String ORALB_BRUSHING_TIME="ORALB_BRUSHING_TIME";
+    public static final String ORALB_BRUSH_ACCELEROMETER="ORALB_BRUSH_ACCELEROMETER";
 
     public static final String ACTIVITY_TYPE="ACTIVITY_TYPE";
     public static final String LED="LED";


### PR DESCRIPTION
- Name of the dataSourceType is ORALB_BRUSH_ACCELEROMETER

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/md2korg/mcerebrum-datakitapi/19)
<!-- Reviewable:end -->
